### PR TITLE
Integrate multihost vpc rapid module

### DIFF
--- a/modules/multihost-vpc/main.tf
+++ b/modules/multihost-vpc/main.tf
@@ -1,0 +1,109 @@
+# Multihost VPC
+resource "aws_vpc" "core" {
+  cidr_block           = var.vpc_cidr_range
+  enable_dns_support   = var.enable_dns_support
+  enable_dns_hostnames = var.enable_dns_hostnames
+
+  tags = merge({ Name = var.vpc_name }, var.tags)
+}
+
+# Public subnets
+resource "aws_subnet" "public_subnet" {
+  count                   = length(data.aws_availability_zones.available.names)
+  vpc_id                  = aws_vpc.core.id
+  cidr_block              = length(var.public_subnet_cidrs) > 0 ? var.public_subnet_cidrs[count.index] : cidrsubnet(var.vpc_cidr_range, var.public_subnet_size, count.index)
+  availability_zone       = data.aws_availability_zones.available.names[count.index]
+  map_public_ip_on_launch = true
+
+  tags = merge({
+    Name = "${local.public_subnet_prefix}_${replace(
+      data.aws_availability_zones.available.names[count.index],
+      "-",
+      "_",
+    )}"
+    Scope = "public" },
+  var.tags)
+}
+
+# IGW - Internet Gateway
+resource "aws_internet_gateway" "core_igw" {
+  vpc_id = aws_vpc.core.id
+
+  tags = merge({
+    Name = "${var.vpc_name}_igw"
+  }, var.tags)
+}
+
+# EIPs for NAT Gateways
+resource "aws_eip" "core_nat_gw_eip" {
+  count = length(data.aws_availability_zones.available.names)
+  vpc   = true
+
+  depends_on = [aws_internet_gateway.core_igw]
+
+  tags = merge({
+    Name = "${var.vpc_name}_nat_gw_eip_${replace(
+      data.aws_availability_zones.available.names[count.index],
+      "-",
+      "_",
+    )}"
+  }, var.tags)
+}
+
+# NAT Gateways for private subnets
+resource "aws_nat_gateway" "core_nat_gw" {
+  count         = length(data.aws_availability_zones.available.names)
+  subnet_id     = aws_subnet.public_subnet[count.index].id
+  allocation_id = aws_eip.core_nat_gw_eip[count.index].id
+
+  tags = merge({
+    Name = "${var.vpc_name}_nat_gw_${replace(
+      data.aws_availability_zones.available.names[count.index],
+      "-",
+      "_",
+    )}"
+  }, var.tags)
+}
+
+# Route tables for public/private subnets
+resource "aws_route_table" "core_main_route_table" {
+  vpc_id = aws_vpc.core.id
+
+  tags = merge({
+    Name = "${var.vpc_name}_main_route_table_name"
+  }, var.tags)
+}
+
+resource "aws_route_table" "core_private_route_table" {
+  count  = length(data.aws_availability_zones.available.names)
+  vpc_id = aws_vpc.core.id
+
+  tags = merge({
+    Name = "${var.vpc_name}_private_route_table_${replace(
+      data.aws_availability_zones.available.names[count.index],
+      "-",
+      "_",
+    )}"
+  }, var.tags)
+}
+
+# Default public route through the IGW
+resource "aws_route" "core_main_route_table_public_default_route" {
+  route_table_id         = aws_route_table.core_main_route_table.id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.core_igw.id
+}
+
+# Default private route through the NAT gateways
+resource "aws_route" "core_private_route_table_default_route" {
+  count                  = length(data.aws_availability_zones.available.names)
+  route_table_id         = aws_route_table.core_private_route_table[count.index].id
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id         = aws_nat_gateway.core_nat_gw[count.index].id
+}
+
+# Route table associations
+resource "aws_main_route_table_association" "core_main_route_table_association" {
+  vpc_id         = aws_vpc.core.id
+  route_table_id = aws_route_table.core_main_route_table.id
+}

--- a/modules/multihost-vpc/outputs.tf
+++ b/modules/multihost-vpc/outputs.tf
@@ -1,0 +1,19 @@
+output "vpc_id" {
+  value       = aws_vpc.core.id
+  description = "The ID of the created VPC"
+}
+
+output "vpc_cidr_range" {
+  value       = aws_vpc.core.cidr_block
+  description = "The ID of the created VPC"
+}
+
+output "private_route_table_ids" {
+  value       = aws_route_table.core_private_route_table[*].id
+  description = "A list of private route table IDs"
+}
+
+output "public_subnet_ids" {
+  value       = aws_subnet.public_subnet[*].id
+  description = "A list of public subnet IDs"
+}

--- a/modules/multihost-vpc/variables.tf
+++ b/modules/multihost-vpc/variables.tf
@@ -1,0 +1,54 @@
+variable "tags" {
+  type        = map(string)
+  description = "A map of tags to apply to all VPC resources"
+  default     = {}
+}
+
+variable "vpc_name" {
+  type        = string
+  description = "The name of the VPC"
+  default     = "core_vpc"
+}
+
+variable "vpc_cidr_range" {
+  type        = string
+  description = "The IP address space to use for the VPC"
+  default     = "10.0.0.0/16"
+}
+#
+variable "public_subnet_cidrs" {
+  type        = list(string)
+  description = "A list of CIDRs for the public subnets. Needs to be the same amount as subnets in the Availability Zone you are deploying into (probably 3)"
+  default     = []
+}
+
+variable "public_subnet_size" {
+  type        = number
+  description = "The size of the public subnet (default: 1022 usable addresses)"
+  default     = "6"
+}
+
+variable "public_subnet_prefix" {
+  type        = string
+  description = "The prefix to attach to the name of the public subnets"
+  default     = ""
+}
+
+variable "enable_dns_support" {
+  type        = bool
+  description = "Whether or not to enable VPC DNS support"
+  default     = true
+}
+
+variable "enable_dns_hostnames" {
+  type        = bool
+  description = "Whether or not to enable VPC DNS hostname support"
+  default     = true
+}
+#
+locals {
+  # We are using locals for this because there already is a fair amount of function calling inside the actual resources
+  public_subnet_prefix = length(var.public_subnet_prefix) > 0 ? var.public_subnet_prefix : "${var.vpc_name}_public_subnet"
+}
+#
+data "aws_availability_zones" "available" {}

--- a/modules/rapid-cluster/main.tf
+++ b/modules/rapid-cluster/main.tf
@@ -20,11 +20,10 @@ module "app_cluster" {
   vpc_id                                          = var.vpc_id
   public_subnet_ids_list                          = var.public_subnet_ids_list
   private_subnet_ids_list                         = var.private_subnet_ids_list
-#  parameter_store_variable_arns                   = [module.auth.protected_scopes_parameter_store_arn]
-  athena_query_output_bucket_arn = module.data_workflow.athena_query_result_output_bucket_arn
-  ip_whitelist                   = var.ip_whitelist
-  allowed_email_domains                           = "no10.gov.uk,cabinetoffice.gov.uk" #TODO: update to variable
-  permissions_table                               = var.user_permission_table_name
+  athena_query_output_bucket_arn                  = module.data_workflow.athena_query_result_output_bucket_arn
+  ip_whitelist                                    = var.ip_whitelist
+  allowed_email_domains                           = var.allowed_email_domains
+  permissions_table                               = module.auth.user_permission_table_name
 }
 
 

--- a/modules/rapid-cluster/main.tf
+++ b/modules/rapid-cluster/main.tf
@@ -23,7 +23,7 @@ module "app_cluster" {
 #  parameter_store_variable_arns                   = [module.auth.protected_scopes_parameter_store_arn]
   athena_query_output_bucket_arn = module.data_workflow.athena_query_result_output_bucket_arn
   ip_whitelist                   = var.ip_whitelist
-  allowed_email_domains                           = "example.com"
+  allowed_email_domains                           = "example.com" #TODO: update to variable
   permissions_table                               = var.user_permission_table_name
 }
 

--- a/modules/rapid-cluster/main.tf
+++ b/modules/rapid-cluster/main.tf
@@ -23,7 +23,7 @@ module "app_cluster" {
 #  parameter_store_variable_arns                   = [module.auth.protected_scopes_parameter_store_arn]
   athena_query_output_bucket_arn = module.data_workflow.athena_query_result_output_bucket_arn
   ip_whitelist                   = var.ip_whitelist
-  allowed_email_domains                           = "example.com" #TODO: update to variable
+  allowed_email_domains                           = "no10.gov.uk,cabinetoffice.gov.uk" #TODO: update to variable
   permissions_table                               = var.user_permission_table_name
 }
 

--- a/modules/rapid-cluster/main.tf
+++ b/modules/rapid-cluster/main.tf
@@ -1,0 +1,73 @@
+module "app_cluster" {
+  # source = "git@github.com:no10ds/rapid-infrastructure.git//modules/app-cluster?ref=1c44ef9aaad8e037279c0972772174c5c246c59a"
+  source                                          = "../app-cluster"
+  app-replica-count-desired                       = var.app-replica-count-desired
+  app-replica-count-max                           = var.app-replica-count-max
+  resource-name-prefix                            = var.resource-name-prefix
+  application_version                             = var.application_version
+  support_emails_for_cloudwatch_alerts            = var.support_emails_for_cloudwatch_alerts
+  cognito_user_login_app_credentials_secrets_name = module.auth.cognito_user_app_secret_manager_name
+  cognito_user_pool_id                            = module.auth.cognito_user_pool_id
+  domain_name                                     = var.domain_name
+  rapid_ecr_url                                   = var.rapid_ecr_url
+  certificate_validation_arn                      = var.certificate_validation_arn
+  hosted_zone_id                                  = var.hosted_zone_id
+  aws_account                                     = var.aws_account
+  aws_region                                      = var.aws_region
+  data_s3_bucket_arn                              = aws_s3_bucket.this.arn
+  data_s3_bucket_name                             = aws_s3_bucket.this.id
+  log_bucket_name                                 = var.log_bucket_name
+  vpc_id                                          = var.vpc_id
+  public_subnet_ids_list                          = var.public_subnet_ids_list
+  private_subnet_ids_list                         = var.private_subnet_ids_list
+#  parameter_store_variable_arns                   = [module.auth.protected_scopes_parameter_store_arn]
+  athena_query_output_bucket_arn = module.data_workflow.athena_query_result_output_bucket_arn
+  ip_whitelist                   = var.ip_whitelist
+  allowed_email_domains                           = "example.com"
+  permissions_table                               = var.user_permission_table_name
+}
+
+
+module "auth" {
+  source               = "../auth"
+  tags                 = var.tags
+  domain_name          = var.domain_name
+  resource-name-prefix = var.resource-name-prefix
+}
+
+module "data_workflow" {
+  source               = "../data-workflow"
+  resource-name-prefix = var.resource-name-prefix
+  aws_account          = var.aws_account
+  data_s3_bucket_arn   = aws_s3_bucket.this.arn
+  data_s3_bucket_name  = aws_s3_bucket.this.id
+  vpc_id               = var.vpc_id
+  private_subnet       = var.private_subnet_ids_list[0]
+  aws_region           = var.aws_region
+}
+
+resource "aws_s3_bucket" "this" {
+  # checkov:skip=CKV_AWS_144:No need for cross region replication
+  bucket = var.resource-name-prefix
+}
+
+resource "aws_s3_bucket_public_access_block" "this" {
+  bucket                  = aws_s3_bucket.this.id
+  ignore_public_acls      = true
+  block_public_acls       = true
+  block_public_policy     = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket" "logs" {
+  # checkov:skip=CKV_AWS_144:No need for cross region replication
+  bucket = var.log_bucket_name
+}
+
+resource "aws_s3_bucket_public_access_block" "logs" {
+  bucket                  = aws_s3_bucket.logs.id
+  ignore_public_acls      = true
+  block_public_acls       = true
+  block_public_policy     = true
+  restrict_public_buckets = true
+}

--- a/modules/rapid-cluster/variables.tf
+++ b/modules/rapid-cluster/variables.tf
@@ -90,7 +90,10 @@ variable "vpc_id" {
   description = "The ID of the multihost VPC"
 }
 
-variable "user_permission_table_name" {}
+variable "allowed_email_domains" {
+  type        = string
+  description = "Email domains that can create a rAPId account"
+}
 
 
 

--- a/modules/rapid-cluster/variables.tf
+++ b/modules/rapid-cluster/variables.tf
@@ -1,0 +1,96 @@
+variable "app-replica-count-desired" {
+  type        = number
+  description = "The desired number of replicas of the app"
+  default     = 1
+}
+
+variable "app-replica-count-max" {
+  type        = number
+  description = "The maximum desired number of replicas of the app"
+  default     = 2
+}
+
+variable "application_version" {
+  type        = string
+  description = "The version number for the application image (e.g.: v1.0.4, v1.0.x-latest, etc.)"
+}
+
+variable "aws_account" {
+  type        = string
+  description = "AWS Account number to host the rAPId service"
+}
+
+variable "aws_region" {
+  type        = string
+  description = "The region of the AWS Account for the rAPId service"
+}
+
+variable "certificate_validation_arn" {
+  type        = string
+  description = "Arn of the certificate used by the domain"
+}
+
+variable "domain_name" {
+  type        = string
+  description = "Domain name for the rAPId instance"
+}
+
+
+variable "hosted_zone_id" {
+  type        = string
+  description = "Hosted Zone ID with the domain Name Servers, pass quotes to create a new one from scratch"
+}
+
+variable "ip_whitelist" {
+  type        = list(string)
+  description = "A list of IPs to whitelist for access to the service"
+}
+
+variable "log_bucket_name" {
+  type        = string
+  description = "The name of the log bucket"
+}
+
+variable "public_subnet_ids_list" {
+  type        = list(string)
+  description = "A list of public subnets from the VPC config"
+}
+
+variable "private_subnet_ids_list" {
+  type        = list(string)
+  description = "A list of private subnets from each organisation network config"
+}
+
+variable "rapid_ecr_url" {
+  type        = string
+  description = "ECR Url for task definition"
+  default     = "public.ecr.aws/no10-rapid/api"
+}
+
+variable "resource-name-prefix" {
+  type        = string
+  description = "organization prefix of for naming"
+}
+
+variable "support_emails_for_cloudwatch_alerts" {
+  type        = list(string)
+  description = "List of emails that will receive alerts from CloudWatch"
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "A common map of tags for all VPC resources that are created (for e.g. billing purposes)"
+  default = {
+    Resource = "data-f1-rapid"
+  }
+}
+
+variable "vpc_id" {
+  type        = string
+  description = "The ID of the multihost VPC"
+}
+
+variable "user_permission_table_name" {}
+
+
+

--- a/modules/subnets/main.tf
+++ b/modules/subnets/main.tf
@@ -1,0 +1,23 @@
+# Subnets
+# Private subnets
+resource "aws_subnet" "private_subnet" {
+  count      = length(data.aws_availability_zones.available.names)
+  vpc_id     = var.vpc_id
+  cidr_block = length(var.private_subnet_cidrs) > 0 ? var.private_subnet_cidrs[count.index] : cidrsubnet(var.vpc_cidr_range, var.private_subnet_size, var.private_subnet_offset + count.index)
+  availability_zone = data.aws_availability_zones.available.names[count.index]
+
+  tags = merge({
+    Name = "${local.private_subnet_prefix}_${replace(
+      data.aws_availability_zones.available.names[count.index],
+      "-",
+      "_",
+    )}"
+    Scope = "private" },
+  var.tags)
+}
+
+resource "aws_route_table_association" "core_private_route_table_association" {
+  count     = length(data.aws_availability_zones.available.names)
+  subnet_id = aws_subnet.private_subnet[count.index].id
+  route_table_id = var.core_private_route_table_ids[count.index]
+}

--- a/modules/subnets/outputs.tf
+++ b/modules/subnets/outputs.tf
@@ -1,0 +1,4 @@
+output "private_subnet_ids" {
+  value       = aws_subnet.private_subnet[*].id
+  description = "A list of private subnet IDs"
+}

--- a/modules/subnets/variables.tf
+++ b/modules/subnets/variables.tf
@@ -1,0 +1,76 @@
+variable "tags" {
+  type        = map(string)
+  description = "A map of tags to apply to all VPC resources"
+  default     = {}
+}
+#
+variable "vpc_name" {
+  type        = string
+  description = "The name of the VPC"
+  default     = "core_vpc"
+}
+#
+variable "vpc_cidr_range" {
+  type        = string
+  description = "The IP address space to use for the VPC"
+}
+
+variable "vpc_id" {
+  type        = string
+  description = "The VPC ID of the core VPC"
+}
+
+variable "core_private_route_table_ids" {
+  type        = list(string)
+  description = "The private route table IDs of the core to route private subnets to the Nat gateways "
+}
+
+variable "public_subnet_cidrs" {
+  type        = list(string)
+  description = "A list of CIDRs for the public subnets. Needs to be the same amount as subnets in the Availability Zone you are deploying into (probably 3)"
+  default     = []
+}
+
+variable "public_subnet_size" {
+  type        = number
+  description = "The size of the public subnet (default: 1022 usable addresses)"
+  default     = "6"
+}
+
+variable "private_subnet_cidrs" {
+  type        = list(string)
+  description = "A list of CIDRs for the private subnets. Needs to be the same amount as subnets in the Availability Zone you are deploying into (probably 3)"
+  default     = []
+}
+
+variable "private_subnet_size" {
+  type        = number
+  description = "The size of the private subnet (default: 1022 usable addresses)"
+  default     = 6
+}
+
+variable "private_subnet_offset" {
+  type        = number
+  description = "The amount of IP space between the public and the private subnet"
+  default     = 32
+}
+
+variable "public_subnet_prefix" {
+  type        = string
+  description = "The prefix to attach to the name of the public subnets"
+  default     = ""
+}
+
+variable "private_subnet_prefix" {
+  type        = string
+  description = "The prefix to attach to the name of the private subnets"
+  default     = ""
+}
+
+locals {
+  # We are using locals for this because there already is a fair amount of function calling inside the actual resources
+  public_subnet_prefix  = length(var.public_subnet_prefix) > 0 ? var.public_subnet_prefix : "${var.vpc_name}_public_subnet"
+  private_subnet_prefix = length(var.private_subnet_prefix) > 0 ? var.private_subnet_prefix : "${var.vpc_name}_private_subnet"
+}
+
+data "aws_availability_zones" "available" {}

--- a/modules/subnets/versions.tf
+++ b/modules/subnets/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12.6"
+}


### PR DESCRIPTION
Allows the rapid-infrastructure to be used by rapid multi instance terragrunt configuration [rapid-multihost-config](https://github.com/no10ds/rapid-multihost-config)