### PR TITLE
2.7 remove inline policies in use

### DIFF
--- a/modules/app-cluster/cloudtrail.tf
+++ b/modules/app-cluster/cloudtrail.tf
@@ -152,39 +152,6 @@ resource "aws_iam_policy_attachment" "aws_iam_policy_cloudtrail_cloudwatch_attac
   roles = [aws_iam_role.cloud_trail_role[0].id]
 }
 
-#resource "aws_iam_role_policy" "aws_iam_role_policy_cloudtrail_cloudwatch" {
-#  count = var.enable_cloudtrail ? 1 : 0
-#  name  = "${var.resource-name-prefix}-cloudtrail-cloudwatch-policy"
-#  role  = aws_iam_role.cloud_trail_role[0].id
-#
-#  policy = <<EOF
-#{
-#    "Version": "2012-10-17",
-#    "Statement": [
-#        {
-#            "Sid": "AWSCloudTrailCreateLogStream2014110",
-#            "Effect": "Allow",
-#            "Action": [
-#                "logs:CreateLogStream"
-#            ],
-#            "Resource": [
-#                "${aws_cloudwatch_log_group.access_logs_log_group[0].arn}:*"
-#            ]
-#        },
-#        {
-#            "Sid": "AWSCloudTrailPutLogEvents20141101",
-#            "Effect": "Allow",
-#            "Action": [
-#                "logs:PutLogEvents"
-#            ],
-#            "Resource": [
-#                "${aws_cloudwatch_log_group.access_logs_log_group[0].arn}:*"
-#            ]
-#        }
-#    ]
-#}
-#EOF
-#}
 
 resource "aws_s3_bucket" "access_logs" {
   count         = var.enable_cloudtrail ? 1 : 0

--- a/modules/app-cluster/cloudtrail.tf
+++ b/modules/app-cluster/cloudtrail.tf
@@ -111,10 +111,10 @@ EOF
   tags = var.tags
 }
 
-resource "aws_iam_role_policy" "aws_iam_role_policy_cloudtrail_cloudwatch" {
-  count = var.enable_cloudtrail ? 1 : 0
-  name  = "${var.resource-name-prefix}-cloudtrail-cloudwatch-policy"
-  role  = aws_iam_role.cloud_trail_role[0].id
+resource "aws_iam_policy" "aws_iam_policy_cloudtrail_cloudwatch" {
+#  count = var.enable_cloudtrail ? 1 : 0
+  name  = "${var.resource-name-prefix}-iam-policy-cloudtrail-cloudwatch"
+#  role  = aws_iam_role.cloud_trail_role[0].id
 
   policy = <<EOF
 {
@@ -144,6 +144,47 @@ resource "aws_iam_role_policy" "aws_iam_role_policy_cloudtrail_cloudwatch" {
 }
 EOF
 }
+
+resource "aws_iam_policy_attachment" "aws_iam_policy_cloudtrail_cloudwatch_attachment" {
+  count = var.enable_cloudtrail ? 1 : 0
+  name       = "${var.resource-name-prefix}-iam-policy-cloudtrail-cloudwatch-attachment"
+  policy_arn = aws_iam_policy.aws_iam_policy_cloudtrail_cloudwatch.arn
+  roles = [aws_iam_role.cloud_trail_role[0].id]
+}
+
+#resource "aws_iam_role_policy" "aws_iam_role_policy_cloudtrail_cloudwatch" {
+#  count = var.enable_cloudtrail ? 1 : 0
+#  name  = "${var.resource-name-prefix}-cloudtrail-cloudwatch-policy"
+#  role  = aws_iam_role.cloud_trail_role[0].id
+#
+#  policy = <<EOF
+#{
+#    "Version": "2012-10-17",
+#    "Statement": [
+#        {
+#            "Sid": "AWSCloudTrailCreateLogStream2014110",
+#            "Effect": "Allow",
+#            "Action": [
+#                "logs:CreateLogStream"
+#            ],
+#            "Resource": [
+#                "${aws_cloudwatch_log_group.access_logs_log_group[0].arn}:*"
+#            ]
+#        },
+#        {
+#            "Sid": "AWSCloudTrailPutLogEvents20141101",
+#            "Effect": "Allow",
+#            "Action": [
+#                "logs:PutLogEvents"
+#            ],
+#            "Resource": [
+#                "${aws_cloudwatch_log_group.access_logs_log_group[0].arn}:*"
+#            ]
+#        }
+#    ]
+#}
+#EOF
+#}
 
 resource "aws_s3_bucket" "access_logs" {
   count         = var.enable_cloudtrail ? 1 : 0


### PR DESCRIPTION
This fixes some of the inline policies picked up by the pentesters https://trello.com/c/CiXet7iM/224-27-iam-inline-policies-in-use
Removed `aws_iam_role_policy` which add an `inline` policy and added a `aws_iam_policy` and `aws_iam_policy_attachment` to create a `custom managed` policy