### PR TITLE
bugfix/dulpicate-certificate-validation

### DIFF
--- a/modules/app-cluster/outputs.tf
+++ b/modules/app-cluster/outputs.tf
@@ -1,16 +1,20 @@
+output "ecs_cluster_arn" {
+  value       = aws_ecs_cluster.aws-ecs-cluster.arn
+  description = "Cluster identifier"
+}
+
+output "ecs_task_execution_role_arn" {
+  value       = aws_iam_role.ecsTaskExecutionRole.arn
+  description = "The ECS task execution role ARN"
+}
+
 output "load_balancer_dns" {
   value       = aws_alb.application_load_balancer.dns_name
   description = "The DNS name of the load balancer"
 }
 
-output "load_balancer_arn" {
-  value       = aws_alb.application_load_balancer.arn
-  description = "The arn of the load balancer"
-}
-
-output "ecs_cluster_arn" {
-  value       = aws_ecs_cluster.aws-ecs-cluster.arn
-  description = "Cluster identifier"
+output "hosted_zone_id" {
+  value = var.hosted_zone_id == "" ? aws_route53_zone.primary-hosted-zone[0].zone_id : ""
 }
 
 output "hosted_zone_name_servers" {
@@ -18,13 +22,9 @@ output "hosted_zone_name_servers" {
   description = "Name servers of the primary hosted zone linked to the domain"
 }
 
-output "hosted_zone_id" {
-  value = var.hosted_zone_id == "" ? aws_route53_zone.primary-hosted-zone[0].zone_id : ""
-}
-
-output "ecs_task_execution_role_arn" {
-  value       = aws_iam_role.ecsTaskExecutionRole.arn
-  description = "The ECS task execution role ARN"
+output "load_balancer_arn" {
+  value       = aws_alb.application_load_balancer.arn
+  description = "The arn of the load balancer"
 }
 
 output "log_error_alarm_notification_arn" {
@@ -35,6 +35,11 @@ output "log_error_alarm_notification_arn" {
 output "rapid_metric_log_error_alarm_arn" {
   value       = aws_cloudwatch_metric_alarm.log-error-alarm.arn
   description = "The arn of the log error alarm metric"
+}
+
+output "route_53_validation_record_fqdns" {
+  value       = [for record in aws_route53_record.rapid_validation_record : record.fqdn]
+  description = "The fqdns of the route53 validation records for the certificate"
 }
 
 output "service_table_arn" {

--- a/modules/app-cluster/routing.tf
+++ b/modules/app-cluster/routing.tf
@@ -17,10 +17,10 @@ resource "aws_acm_certificate" "rapid-certificate" {
   }
 }
 
-
 locals {
   domain_validation_options = var.certificate_validation_arn == "" ? aws_acm_certificate.rapid-certificate[0].domain_validation_options : []
 }
+
 # Add the Route53 validation record
 resource "aws_route53_record" "rapid_validation_record" {
   for_each = {

--- a/modules/rapid/main.tf
+++ b/modules/rapid/main.tf
@@ -58,6 +58,7 @@ module "ui" {
   aws_account                        = var.aws_account
   ui_version                         = var.ui_version
   load_balancer_dns                  = module.app_cluster.load_balancer_dns
+  route_53_validation_record_fqdns   = module.app_cluster.route_53_validation_record_fqdns
 }
 
 resource "aws_s3_bucket" "this" {

--- a/modules/ui/cloudfront.tf
+++ b/modules/ui/cloudfront.tf
@@ -152,24 +152,7 @@ resource "aws_route53_record" "route-to-cloudfront" {
 }
 
 locals {
-  domain_validation_options = var.us_east_certificate_validation_arn == "" ? aws_acm_certificate.rapid-certificate[0].domain_validation_options : []
   domain_certificate_arn    = var.us_east_certificate_validation_arn == "" ? aws_acm_certificate.rapid-certificate[0].arn : var.us_east_certificate_validation_arn
-}
-
-resource "aws_route53_record" "rapid-validation_record" {
-  for_each = {
-    for dvo in local.domain_validation_options : dvo.domain_name => {
-      name   = dvo.resource_record_name
-      record = dvo.resource_record_value
-      type   = dvo.resource_record_type
-    }
-  }
-
-  zone_id = var.hosted_zone_id
-  name    = each.value.name
-  records = [each.value.record]
-  type    = each.value.type
-  ttl     = 60
 }
 
 resource "aws_acm_certificate" "rapid-certificate" {

--- a/modules/ui/cloudfront.tf
+++ b/modules/ui/cloudfront.tf
@@ -152,10 +152,29 @@ resource "aws_route53_record" "route-to-cloudfront" {
 }
 
 locals {
-  domain_certificate_arn    = var.us_east_certificate_validation_arn == "" ? aws_acm_certificate.rapid-certificate[0].arn : var.us_east_certificate_validation_arn
+  domain_certificate_arn    = var.us_east_certificate_validation_arn == "" ? aws_acm_certificate.rapid_certificate[0].arn : var.us_east_certificate_validation_arn
+  domain_validation_options = var.us_east_certificate_validation_arn == "" ? aws_acm_certificate.rapid_certificate[0].domain_validation_options : []
 }
 
-resource "aws_acm_certificate" "rapid-certificate" {
+resource "aws_route53_record" "rapid_validation_record" {
+  for_each = {
+    for dvo in local.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+    if length(var.route_53_validation_record_fqdns) == 0
+  }
+
+  zone_id = var.hosted_zone_id
+  name    = each.value.name
+  records = [each.value.record]
+  type    = each.value.type
+  ttl     = 60
+}
+
+
+resource "aws_acm_certificate" "rapid_certificate" {
   provider          = aws.us_east
   count             = var.us_east_certificate_validation_arn == "" ? 1 : 0
   domain_name       = var.domain_name
@@ -164,4 +183,11 @@ resource "aws_acm_certificate" "rapid-certificate" {
   lifecycle {
     create_before_destroy = true
   }
+}
+
+resource "aws_acm_certificate_validation" "rapid_certificate" {
+  provider                = aws.us_east
+  count                   = var.us_east_certificate_validation_arn == "" ? 1 : 0
+  certificate_arn         = aws_acm_certificate.rapid_certificate[0].arn
+  validation_record_fqdns = length(var.route_53_validation_record_fqdns) == 0 ? [for record in aws_route53_record.rapid_validation_record : record.fqdn] :  var.route_53_validation_record_fqdns
 }

--- a/modules/ui/variables.tf
+++ b/modules/ui/variables.tf
@@ -47,3 +47,9 @@ variable "load_balancer_dns" {
   type        = string
   description = "The DNS name of the load balancer"
 }
+
+variable "route_53_validation_record_fqdns" {
+  type        = list(string)
+  description = "The fqdns of the route53 validation records for the load balancer certificate"
+  default     = []
+}


### PR DESCRIPTION
The code is using the provided value for the `domain_name` parameter to create two identical AWS ACM certificates

One certificate is created in `us-east-1` for a CloudFront distribution.
The second certificate is created in `eu-west-2` for an https listener on a load balancer. 

The domain validation records can only be created once (for the same certiificate); the second attempt will fail as the records already exist in route53. 

Terraform error: 
![Screenshot 2023-03-01 at 13 45 16](https://user-images.githubusercontent.com/109291504/222156280-d86a4260-a9ca-4fd8-9bab-7cbc0780006a.png)

The error does not cause the creation of either of the certificates to fail.

This PR removes the creation of the duplicate domain validation records.

New tag also required.