### PR TITLE
feature/fix-static-ui-bucket-creation-failure

### DIFF
--- a/blocks/data-workflow/main.tf
+++ b/blocks/data-workflow/main.tf
@@ -27,7 +27,7 @@ data "terraform_remote_state" "vpc-state" {
 }
 
 data "terraform_remote_state" "s3-state" {
-  backend = "s3"
+  backend   = "s3"
   workspace = terraform.workspace
   config = {
     key    = "s3/terraform.tfstate"

--- a/modules/ui/README.md
+++ b/modules/ui/README.md
@@ -38,8 +38,8 @@ No modules.
 | [aws_wafv2_ip_set.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_ip_set) | resource |
 | [aws_wafv2_web_acl.rapid_acl](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl) | resource |
 | [null_resource.download_static_ui](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [random_string.bucket_id](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 | [random_string.random_cloudfront_header](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
-| [random_uuid.bucket_id](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/uuid) | resource |
 | [aws_cloudfront_cache_policy.optimised](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/cloudfront_cache_policy) | data source |
 | [aws_iam_policy_document.s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |

--- a/modules/ui/cloudfront.tf
+++ b/modules/ui/cloudfront.tf
@@ -63,7 +63,7 @@ resource "aws_cloudfront_distribution" "rapid_ui" {
   web_acl_id          = aws_wafv2_web_acl.rapid_acl.arn
 
   depends_on = [
-    random_uuid.bucket_id,
+    random_string.bucket_id,
     aws_s3_bucket.rapid_ui,
   ]
 
@@ -189,5 +189,5 @@ resource "aws_acm_certificate_validation" "rapid_certificate" {
   provider                = aws.us_east
   count                   = var.us_east_certificate_validation_arn == "" ? 1 : 0
   certificate_arn         = aws_acm_certificate.rapid_certificate[0].arn
-  validation_record_fqdns = length(var.route_53_validation_record_fqdns) == 0 ? [for record in aws_route53_record.rapid_validation_record : record.fqdn] :  var.route_53_validation_record_fqdns
+  validation_record_fqdns = length(var.route_53_validation_record_fqdns) == 0 ? [for record in aws_route53_record.rapid_validation_record : record.fqdn] : var.route_53_validation_record_fqdns
 }

--- a/modules/ui/s3.tf
+++ b/modules/ui/s3.tf
@@ -1,4 +1,7 @@
-resource "random_uuid" "bucket_id" {
+resource "random_string" "bucket_id" {
+  length  = 8
+  special = false
+  upper   = false
 }
 
 resource "aws_s3_bucket" "rapid_ui" {
@@ -6,7 +9,7 @@ resource "aws_s3_bucket" "rapid_ui" {
   #checkov:skip=CKV_AWS_145:No need for non default key
   #checkov:skip=CKV_AWS_19:No need for securely encrypted at rest
   #checkov:skip=CKV2_AWS_6:No need for public access block
-  bucket        = "${var.resource-name-prefix}-static-ui-${random_uuid.bucket_id.result}"
+  bucket        = "${var.resource-name-prefix}-static-ui-${random_string.bucket_id.result}"
   force_destroy = true
   tags          = var.tags
 


### PR DESCRIPTION
**Context**
When creating the static-ui bucket, using the `randon_uuid` in the bucket name can cause bucket creation to fail, as the 63 character limit for an s3 bucket is exceeded.

**This PR**
1. Replaces `random_uuid` with a `random_suffix` of 8 characters.
2. Applies a terraform fmt to all code.
3. Updates the `ui` README.